### PR TITLE
feat/#1 게시글 상세 페이지 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,15 @@
 import UserLoginProvider from './providers/AuthProvider';
+import UserProfilesProvider from './providers/UserProfilesProvider';
 import Router from './shared/router';
 import { GlobalStyles } from './styles/globalStyles';
 
 function App() {
   return (
     <UserLoginProvider>
-      <GlobalStyles />
-      <Router />
+      <UserProfilesProvider>
+        <GlobalStyles />
+        <Router />
+      </UserProfilesProvider>
     </UserLoginProvider>
   );
 }

--- a/src/components/FoodCategoryTag.jsx
+++ b/src/components/FoodCategoryTag.jsx
@@ -28,6 +28,8 @@ const FoodCategoryTag = ({ category }) => {
 };
 
 const StCategoryLabels = styled.span`
+  position: absolute;
+  right: -65px; /* 라벨 크기만큼 오른쪽으로 이동 */
   padding: 8px 18px;
   background-color: ${(props) => props.$backgroundColor || '#fefefe'};
 `;

--- a/src/components/PostCommentArea.jsx
+++ b/src/components/PostCommentArea.jsx
@@ -1,0 +1,55 @@
+import { useContext, useState } from 'react';
+import { UserLoginContext } from '../providers/AuthProvider';
+
+const PostComment = ({ comments, handleAddComment }) => {
+  const { isLogin, user } = useContext(UserLoginContext);
+  const [commentInputValue, setCommentInputValue] = useState([]); // 댓글 입력 input
+
+  return (
+    <>
+      <h2>댓글</h2>
+      {isLogin && (
+        <div className="inputRow">
+          <input
+            type="text"
+            name=""
+            id=""
+            value={commentInputValue}
+            onChange={(e) => {
+              setCommentInputValue(e.target.value);
+            }}
+          />
+          <button
+            type="button"
+            onClick={() => {
+              handleAddComment(commentInputValue);
+              setCommentInputValue('');
+            }}
+          >
+            작성
+          </button>
+        </div>
+      )}
+      <ul>
+        {Array.isArray(comments) &&
+          comments.map((comment) => (
+            <li key={comment.id}>
+              <div className="commentTopRow">
+                <p>
+                  <img src={comment.writer_image} />
+                  <span>{comment.writer_nickname}</span>
+                </p>
+                <div>
+                  <button type="button">수정</button>
+                  <button type="button">삭제</button>
+                </div>
+              </div>
+              <p className="commentBottomRow">{comment.comments}</p>
+            </li>
+          ))}
+      </ul>
+    </>
+  );
+};
+
+export default PostComment;

--- a/src/components/PostDetailCard.jsx
+++ b/src/components/PostDetailCard.jsx
@@ -1,0 +1,143 @@
+import FoodCategoryTag from './foodCategoryTag';
+import { useEffect, useState, useContext } from 'react';
+import supabase from '../shared/supabaseClient';
+import { UserProfileContext } from '../providers/UserProfilesProvider';
+import {
+  StDetailSection,
+  StCommentSection,
+  StDetailBox,
+} from '../styles/detailCard.styled';
+import PostCommentArea from './PostCommentArea';
+import { UserLoginContext } from '../providers/AuthProvider';
+
+const PostDetailCard = (post) => {
+  const allUserProfiles = useContext(UserProfileContext);
+  const { user } = useContext(UserLoginContext);
+  const [writer, setWriter] = useState(null); // 게시글 작성자
+  const [comments, setComments] = useState([]); // 댓글 목록 데이터
+  // const [commentInputValue, setCommentInputValue] = useState([]); // 댓글 입력 input
+
+  useEffect(() => {
+    // 유저 프로필값이 들어왔을 때
+    if (allUserProfiles.length) {
+      setWriter(
+        allUserProfiles.find((data) => data.user_id === post.writer_id),
+      );
+    }
+  }, [allUserProfiles, post.writer_id]);
+
+  useEffect(() => {
+    const fetchCommentsData = async () => {
+      // 댓글 데이터 불러오기
+      const { data: commentsData, error: commentError } = await supabase
+        .from('comments')
+        .select('*')
+        .eq('post_id', post.id);
+
+      if (commentError) {
+        console.log('commentError ', commentError);
+        return;
+      }
+
+      setComments(
+        commentsData.map((comment) =>
+          setCommentedUserInfo(allUserProfiles, comment),
+        ),
+      );
+    };
+
+    fetchCommentsData();
+  }, [allUserProfiles, post.id]);
+
+  // * 댓글 추가
+  const handleAddComment = async (commentInputValue) => {
+    const { data: commentsData, error: commentsError } = await supabase
+      .from('comments')
+      .insert({
+        comments: commentInputValue,
+        writer_id: user.id,
+        post_id: post.id,
+      })
+      .select();
+
+    if (commentsError) {
+      console.log('commentsError =====>', commentsError);
+      return;
+    }
+
+    setComments([
+      ...comments,
+      setCommentedUserInfo(allUserProfiles, commentsData[0]),
+    ]);
+  };
+
+  const setCommentedUserInfo = (profileData, comment) => {
+    const commentWriterProfile = profileData.find(
+      (profile) => profile.user_id === comment.writer_id,
+    );
+
+    return {
+      ...comment,
+      writer_nickname: commentWriterProfile?.nickname,
+      writer_image: commentWriterProfile?.image,
+    };
+  };
+
+  return (
+    <>
+      <StDetailSection>
+        <div className="userRow">
+          {writer && (
+            <div>
+              <img
+                src={writer.image}
+                className="userProfile"
+                alt="작성자 프로필"
+              />
+              <span>{writer.nickname}</span>
+            </div>
+          )}
+
+          {/* <div className="btn-row"></div> */}
+        </div>
+        <StDetailBox>
+          <div className="detail-left">
+            <img src={post.image_url} alt="음식 이미지" />
+            <div>
+              <h2>{post.restaurant_name}</h2>
+              <span>{post.restaurant_location}</span>
+            </div>
+            <span>{post.created_at.split('T')[0]}</span>
+          </div>
+          <ul>
+            <li>
+              <h3>추천 메뉴</h3>
+              <p>{post.recommended_menu}</p>
+            </li>
+            <li>
+              <h3>가격대</h3>
+              <p>{post.price_range}</p>
+            </li>
+            <li>
+              <h3>주소</h3>
+              <p>{post.restaurant_address}</p>
+            </li>
+            <li>
+              <h3>내용</h3>
+              <p>{post.content}</p>
+            </li>
+          </ul>
+          <FoodCategoryTag category={post.category} />
+        </StDetailBox>
+      </StDetailSection>
+      <StCommentSection>
+        <PostCommentArea
+          comments={comments}
+          handleAddComment={handleAddComment}
+        />
+      </StCommentSection>
+    </>
+  );
+};
+
+export default PostDetailCard;

--- a/src/pages/PostDetail.jsx
+++ b/src/pages/PostDetail.jsx
@@ -1,23 +1,46 @@
 import React, { useEffect, useState } from 'react';
 import supabase from '../shared/supabaseClient';
+import { useParams } from 'react-router-dom';
+import PostDetailCard from '../components/PostDetailCard';
+import styled from 'styled-components';
 
 const PostDetail = () => {
-  const [users, setUsers] = useState([]);
+  const { id } = useParams();
+  const [post, setPost] = useState(undefined);
+  const { user, setUsers } = useState({});
 
   useEffect(() => {
     const fetchData = async () => {
-      const { data, error } = await supabase.from('TASTY_DB').select('*');
+      const { data, error } = await supabase.from('posts').select('*');
       if (error) {
         console.log('error=> ', error);
-      } else {
-        console.log('data=> ', data);
-        setUsers(data);
+        return;
       }
+
+      const [filteredPost] = data.filter((data) => data.id === Number(id));
+      setPost(filteredPost);
     };
     fetchData();
-  }, []);
+  }, [id]);
 
-  return <div>PostDetail</div>;
+  return (
+    <StContainer>
+      {post ? <PostDetailCard {...post} /> : <div>로딩중</div>}
+    </StContainer>
+  );
 };
 
 export default PostDetail;
+
+const StContainer = styled.div`
+  width: 100%;
+  min-width: 1100px;
+  min-height: 100vh;
+  display: flex;
+  flex-flow: column nowrap;
+  gap: 50px;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--color-white);
+  padding: 200px 0;
+`;

--- a/src/providers/UserProfilesProvider.jsx
+++ b/src/providers/UserProfilesProvider.jsx
@@ -1,0 +1,37 @@
+import { createContext, useEffect, useState } from 'react';
+import supabase from '../shared/supabaseClient';
+
+// * Profiles DB context
+export const UserProfileContext = createContext();
+
+const UserProfilesProvider = ({ children }) => {
+  const [allUserProfiles, setAllUserProfiles] = useState([]);
+
+  useEffect(() => {
+    const fetchUserProfiles = async () => {
+      const { data: profileData, error: profileError } = await supabase
+        .from('profiles')
+        .select('*');
+
+      if (profileError) {
+        console.log('profileError=> ', profileError);
+        return;
+      }
+
+      if (profileData) {
+        setAllUserProfiles(profileData);
+      } else {
+        setAllUserProfiles(null);
+      }
+    };
+    fetchUserProfiles();
+  }, []);
+
+  return (
+    <UserProfileContext.Provider value={allUserProfiles}>
+      {children}
+    </UserProfileContext.Provider>
+  );
+};
+
+export default UserProfilesProvider;

--- a/src/shared/Router.jsx
+++ b/src/shared/Router.jsx
@@ -15,7 +15,7 @@ const Router = () => {
         <Route path="/signup" element={<Signup />}></Route>
         <Route path="/mypage" element={<MyPage />}></Route>
         <Route path="/post-write" element={<PostWrite />}></Route>
-        <Route path="/post-detail" element={<PostDetail />}></Route>
+        <Route path="/post-detail/:id" element={<PostDetail />}></Route>
       </Routes>
     </BrowserRouter>
   );

--- a/src/styles/detailCard.styled.js
+++ b/src/styles/detailCard.styled.js
@@ -1,0 +1,153 @@
+import styled from 'styled-components';
+
+export const StDetailSection = styled.section`
+  display: flex;
+  width: 75%;
+  max-width: 1100px;
+  flex-flow: column nowrap;
+  gap: 30px;
+
+  .userRow {
+    display: flex;
+    justify-content: space-between;
+  }
+  .userRow span {
+    font-size: 26px;
+  }
+  .userRow > div {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+  }
+
+  .userProfile {
+    display: block;
+    width: 50px;
+    height: 50px;
+    border-radius: 50%;
+    overflow: hidden;
+  }
+`;
+
+export const StDetailBox = styled.div`
+  position: relative;
+  display: flex;
+  width: 100%;
+  border-radius: 20px;
+  padding: 74px 70px;
+  gap: 8%;
+  border: solid 1px var(--color-gray);
+  background-color: var(--color-white);
+  box-shadow: 0 4px 8px 3px #00000015;
+
+  div {
+    flex-shrink: 1;
+    max-width: 400px;
+    min-width: 200px;
+  }
+
+  .detail-left h2 {
+    font-size: 26px;
+  }
+
+  .detail-left div {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin: 30px 0;
+  }
+  .detail-left span {
+    font-size: 18px;
+  }
+  ul {
+    flex-grow: 1;
+    min-width: 400px;
+  }
+
+  li {
+    padding: 20px;
+    border-radius: 10px;
+    border: solid 1px var(--color-gray);
+  }
+
+  li + li {
+    margin-top: 30px;
+  }
+
+  h3 {
+    font-size: 20px;
+    margin-bottom: 6px;
+  }
+
+  img {
+    width: 100%;
+    aspect-ratio: 1/1;
+    object-fit: cover;
+  }
+`;
+
+export const StCommentSection = styled.section`
+  display: flex;
+  width: 75%;
+  max-width: 1100px;
+  flex-flow: column nowrap;
+  gap: 30px;
+  border-radius: 20px;
+  padding: 50px 70px;
+  border: solid 1px var(--color-gray);
+  background-color: var(--color-beige);
+  box-shadow: 0 4px 8px 3px #00000015;
+
+  h2 {
+    font-size: 26px;
+  }
+
+  .inputRow {
+    display: flex;
+    gap: 6px;
+  }
+  .inputRow button {
+    width: 80px;
+    height: 50px;
+    background-color: var(--color-green);
+    color: var(--color-white);
+    border: none;
+    border-radius: 16px;
+    cursor: pointer;
+  }
+
+  input {
+    border: none;
+    background-color: var(--color-white);
+    flex: 1;
+    height: 50px;
+    border-radius: 12px;
+    padding-left: 20px;
+  }
+  input:focus {
+    outline: none;
+  }
+  li + li {
+    margin-top: 40px;
+  }
+
+  .commentTopRow {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding-bottom: 20px;
+    margin-bottom: 20px;
+    border-bottom: solid 1px var(--color-gray);
+  }
+  .commentTopRow p {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    font-size: 18px;
+  }
+  .commentTopRow img {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+  }
+`;

--- a/src/styles/globalStyles.js
+++ b/src/styles/globalStyles.js
@@ -9,12 +9,13 @@ export const GlobalStyles = createGlobalStyle`
     --color-green: #95b645;
   }
 
-  body {
+  body, button {
     font-family: 'Pretendard Variable', Pretendard, sans-serif;
     font-weight: 400;
     line-height: 1.4;
-    font-size: 18px;
+    font-size: 16px;
     letter-spacing: -0.002em;
     color: var(--color-black);
   }
+
 `;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #1 

<br>

## 📝 작업 내용

> 게시글 상세 페이지 조회와 댓글 기능 일부를 구현했습니다.

- useParams를 활용한 라우팅 구현
- 해당 글을 작성한 유저의 프로필/ 닉네임 노출
- supabase내 posts 데이터 연동 및 노출
- supabase 내 모든 사용자의 프로필 데이터가 담긴 profiles 데이터를 전역 상태로 추가
- 리스트 페이지에서 함께 사용할 음식 카테고리 라벨 스타일링 수정
- 댓글 컴포넌트 추가
- 상세 페이지 내 단순 스타일링을 위한 컴포넌트 추가

<br>

## 🖼 스크린샷
![image](https://github.com/user-attachments/assets/bced9fd0-c78c-4b12-bf77-0fcd6f0ea267)

<br>

## 💬리뷰 요구사항
- 리뷰 예상 시간 : `10분`
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 전역 상태로 추가된 UserProfilesProvider 데이터를 확인하셔서 추후 활용해주세요!