### PR TITLE
Feat/make detail page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,130 @@
-# React + Vite
+<div align="center">
+  <img width="450" alt="프로젝트 로고" src="https://github.com/user-attachments/assets/564bdcaf-76de-4899-95b6-d1c5dfffe1c7" />
+</div>
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+<br>
+<br>
 
-Currently, two official plugins are available:
+## 💬 프로젝트 소개
+**같이 알고 싶은 나만의 맛집을 공유하자!**
+<br><br>
+전국 각지의 감chill맛 나는 맛집을 함께 나눠요! 현지인만 아는 숨겨진 맛집을 알게 될 지도? 🤫
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+> - **작업 기간** : 2025. 02. 12 ~ 2025. 02. 17 
+> - **배포 주소** : url
+
+<br />
+
+
+## 👩‍👩‍👧‍👧 프로젝트 멤버 소개
+<table>
+  <tbody>
+    <tr>
+      <td align="center">
+        <a href="https://github.com/jiyxxn">
+        <img src="https://github.com/jiyxxn.png" width="80" alt="jiyxxn"/>
+        <br />
+        <sub><b>jiyxxn</b></sub>
+        </a>
+        <br />
+      </td>
+      <td align="center">
+        <a href="https://github.com/99ShinByeongseon">
+        <img src="https://github.com/99ShinByeongseon.png" width="80" alt="99ShinByeongseon"/>
+        <br />
+        <sub><b>99ShinByeongseon</b></sub>
+        </a>
+        <br />
+      </td>
+      <td align="center">
+        <a href="https://github.com/dlfhrrl12">
+        <img src="https://github.com/dlfhrrl12.png" width="80" alt="dlfhrrl12"/>
+        <br />
+        <sub><b>dlfhrrl12</b></sub>
+        </a>
+        <br />
+      </td>
+      <td align="center">
+        <a href="https://github.com/smileeeeely">
+        <img src="https://github.com/smileeeeely.png" width="80" alt="smileeeeely"/>
+        <br />
+        <sub><b>smileeeeely</b></sub>
+        </a>
+        <br />
+      </td>
+      <td align="center">
+        <a href="https://github.com/sohxxny">
+        <img src="https://github.com/sohxxny.png" width="80" alt="sohxxny"/>
+        <br />
+        <sub><b>sohxxny</b></sub>
+        </a>
+        <br />
+      </td>      
+    </tr>
+    <tr>
+      <td width="200px" align="center">
+        PM
+        <br>프로젝트 디자인
+        <br>게시글 상세 구현
+      </td>
+      <td width="200px" align="center">
+        게시글 목록 구현
+      </td>
+      <td width="200px" align="center">
+        로그인 및 헤더 구현
+      </td>
+      <td width="200px" align="center">
+      게시글 작성/수정 구현
+      </td>
+      <td width="200px" align="center">
+      회원가입 구현
+        <br>마이페이지 구현
+      </td>      
+    </tr>
+  </tbody>
+</table>
+
+<br />
+
+## ⚙ 프로젝트 기능 소개
+- 뭐가 있구요
+- 뭐도 있고요
+- 뭐도 있어요
+
+<br>
+
+## 🚀 트러블 슈팅
+- #### [[카테고리] 임시]()
+
+
+<br />
+
+## 📁 프로젝트 구조
+```markdown
+📁
+|- src/
+|   |- index.html
+```
+
+<br />
+
+## 🧶 기술 스택
+<div align="left">
+
+### Environment
+<img src="https://img.shields.io/badge/Visual_Studio_Code-007ACC?style=for-the-badge&logo=https://upload.wikimedia.org/wikipedia/commons/a/a7/Visual_Studio_Code_1.35_icon.svg&logoColor=white" />
+<img src="https://img.shields.io/badge/Git-F05032?style=for-the-badge&logo=git&logoColor=white" />
+<img src="https://img.shields.io/badge/GitHub-181717?style=for-the-badge&logo=github&logoColor=white" />
+<br>
+
+### Development
+<img src="https://img.shields.io/badge/React-61DAFB?style=for-the-badge&logo=React&logoColor=black"/>
+<img src="https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=JavaScript&logoColor=white"/>
+<img src="https://img.shields.io/badge/styled components-DB7093?style=for-the-badge&amp;logo=styled-components&amp;logoColor=white">
+
+### Record
+<a href="https://www.figma.com/design/SnKoaJ8xQiLnqNhDQUaJEx/%EA%B0%90Chill%EB%A7%9B-%EB%B0%B1%EA%B3%BC?node-id=0-1&t=zT9Fy8RWzbVdfSol-1" target="blank"><img src="https://img.shields.io/badge/Figma-F24E1E?style=for-the-badge&logo=figma&logoColor=white" alt="Figma" /></a>
+<a href="https://www.notion.so/teamsparta/7-_chill-b92286d960044bd3923b6107df8497da" target="blank"><img src="https://img.shields.io/badge/Notion-000000?style=for-the-badge&logo=notion&logoColor=white" alt="Notion" /></a>
+
+<br>
+

--- a/src/components/PostCommentArea.jsx
+++ b/src/components/PostCommentArea.jsx
@@ -1,10 +1,43 @@
 import { useContext, useState } from 'react';
 import { UserLoginContext } from '../providers/AuthProvider';
 
-const PostComment = ({ comments, handleAddComment }) => {
+const PostComment = ({
+  comments,
+  handleAddComment,
+  handleUpdateComment,
+  handleDeleteComment,
+}) => {
   const { isLogin, user } = useContext(UserLoginContext);
   const [commentInputValue, setCommentInputValue] = useState([]); // 댓글 입력 input
+  const [isUpdating, setIsUpdating] = useState({});
+  const [commentUpdateValue, setCommentUpdateValue] = useState('');
 
+  const onToggleUpdateComment = (e, commentId, comments) => {
+    const buttonType = e.target.getAttribute('data-type');
+
+    // '수정' 버튼 클릭 시
+    if (buttonType === 'modify') {
+      setIsUpdating((prev) => ({ ...prev, [commentId]: true }));
+      setCommentUpdateValue(comments); // 노출된 수정 input에 수정 전 텍스트 반영
+      e.target.innerText = '완료';
+      e.target.setAttribute('data-type', 'complete');
+    } else if (buttonType === 'complete') {
+      // '완료' 버튼 클릭 시
+      handleUpdateComment(commentUpdateValue, commentId);
+      setIsUpdating((prev) => ({ ...prev, [commentId]: false }));
+      setCommentUpdateValue(''); // 수정이 완료되면 수정 input의 value 초기화
+      e.target.innerText = '수정';
+      e.target.setAttribute('data-type', 'modify');
+    }
+  };
+
+  const onDeleteComment = (commentId) => {
+    const isConfirmed = confirm('정말 삭제하시겠습니까?');
+
+    isConfirmed ? handleDeleteComment(commentId) : false;
+  };
+
+  console.log('commentUpdateValue =====>', commentUpdateValue);
   return (
     <>
       <h2>댓글</h2>
@@ -36,15 +69,46 @@ const PostComment = ({ comments, handleAddComment }) => {
             <li key={comment.id}>
               <div className="commentTopRow">
                 <p>
-                  <img src={comment.writer_image} />
-                  <span>{comment.writer_nickname}</span>
+                  <img src={comment.profiles.image} />
+                  <span>{comment.profiles.nickname}</span>
                 </p>
                 <div>
-                  <button type="button">수정</button>
-                  <button type="button">삭제</button>
+                  {comment.writer_id === user.id && (
+                    <>
+                      <button
+                        type="button"
+                        data-type="modify"
+                        onClick={(e) => {
+                          onToggleUpdateComment(
+                            e,
+                            comment.id,
+                            comment.comments,
+                          );
+                        }}
+                      >
+                        수정
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => onDeleteComment(comment.id)}
+                      >
+                        삭제
+                      </button>
+                    </>
+                  )}
                 </div>
               </div>
-              <p className="commentBottomRow">{comment.comments}</p>
+              <div className="commentBottomRow">
+                {isUpdating[comment.id] ? (
+                  <input
+                    type="text"
+                    value={commentUpdateValue}
+                    onChange={(e) => setCommentUpdateValue(e.target.value)}
+                  ></input>
+                ) : (
+                  <p>{comment.comments}</p>
+                )}
+              </div>
             </li>
           ))}
       </ul>

--- a/src/components/PostCommentArea.jsx
+++ b/src/components/PostCommentArea.jsx
@@ -9,7 +9,7 @@ const PostComment = ({
 }) => {
   const { isLogin, user } = useContext(UserLoginContext);
   const [commentInputValue, setCommentInputValue] = useState([]); // 댓글 입력 input
-  const [isUpdating, setIsUpdating] = useState({});
+  const [isCommentUpdating, setIsCommentUpdating] = useState({});
   const [commentUpdateValue, setCommentUpdateValue] = useState('');
 
   const onToggleUpdateComment = (e, commentId, comments) => {
@@ -17,14 +17,14 @@ const PostComment = ({
 
     // '수정' 버튼 클릭 시
     if (buttonType === 'modify') {
-      setIsUpdating((prev) => ({ ...prev, [commentId]: true }));
+      setIsCommentUpdating((prev) => ({ ...prev, [commentId]: true }));
       setCommentUpdateValue(comments); // 노출된 수정 input에 수정 전 텍스트 반영
       e.target.innerText = '완료';
       e.target.setAttribute('data-type', 'complete');
     } else if (buttonType === 'complete') {
       // '완료' 버튼 클릭 시
       handleUpdateComment(commentUpdateValue, commentId);
-      setIsUpdating((prev) => ({ ...prev, [commentId]: false }));
+      setIsCommentUpdating((prev) => ({ ...prev, [commentId]: false }));
       setCommentUpdateValue(''); // 수정이 완료되면 수정 input의 value 초기화
       e.target.innerText = '수정';
       e.target.setAttribute('data-type', 'modify');
@@ -37,7 +37,6 @@ const PostComment = ({
     isConfirmed ? handleDeleteComment(commentId) : false;
   };
 
-  console.log('commentUpdateValue =====>', commentUpdateValue);
   return (
     <>
       <h2>댓글</h2>
@@ -99,7 +98,7 @@ const PostComment = ({
                 </div>
               </div>
               <div className="commentBottomRow">
-                {isUpdating[comment.id] ? (
+                {isCommentUpdating[comment.id] ? (
                   <input
                     type="text"
                     value={commentUpdateValue}

--- a/src/components/PostDetailCard.jsx
+++ b/src/components/PostDetailCard.jsx
@@ -26,8 +26,8 @@ const PostDetailCard = (post) => {
   }, [allUserProfiles, post.writer_id]);
 
   useEffect(() => {
+    // * 댓글 호출
     const fetchCommentsData = async () => {
-      // 댓글 데이터 불러오기
       const { data: commentsData, error } = await supabase
         .from('comments')
         .select('* , profiles(nickname, image)')
@@ -47,7 +47,7 @@ const PostDetailCard = (post) => {
 
   // * 댓글 추가
   const handleAddComment = async (commentInputValue) => {
-    const { data: insertedCommentsData, error } = await supabase
+    const { data: insertedCommentData, error } = await supabase
       .from('comments')
       .insert({
         comments: commentInputValue,
@@ -62,12 +62,12 @@ const PostDetailCard = (post) => {
       return;
     }
 
-    setComments([...comments, insertedCommentsData]);
+    setComments([...comments, insertedCommentData]);
   };
 
   // * 댓글 수정
   const handleUpdateComment = async (commentInputValue, commentId) => {
-    const { data: updatedComments, error } = await supabase
+    const { data: updatedComment, error } = await supabase
       .from('comments')
       .update({
         comments: commentInputValue,
@@ -84,7 +84,7 @@ const PostDetailCard = (post) => {
     // comments 상태에 update 사항 반영
     setComments((prevComments) =>
       prevComments.map((comment) =>
-        comment.id === commentId ? updatedComments : comment,
+        comment.id === commentId ? updatedComment : comment,
       ),
     );
   };
@@ -119,9 +119,8 @@ const PostDetailCard = (post) => {
               <span>{writer.nickname}</span>
             </div>
           )}
-
-          {/* <div className="btn-row"></div> */}
         </div>
+
         <StDetailBox>
           <div className="detail-left">
             <img src={post.image_url} alt="음식 이미지" />

--- a/src/components/PostDetailCard.jsx
+++ b/src/components/PostDetailCard.jsx
@@ -15,7 +15,6 @@ const PostDetailCard = (post) => {
   const { user } = useContext(UserLoginContext);
   const [writer, setWriter] = useState(null); // 게시글 작성자
   const [comments, setComments] = useState([]); // 댓글 목록 데이터
-  // const [commentInputValue, setCommentInputValue] = useState([]); // 댓글 입력 input
 
   useEffect(() => {
     // 유저 프로필값이 들어왔을 때
@@ -29,21 +28,18 @@ const PostDetailCard = (post) => {
   useEffect(() => {
     const fetchCommentsData = async () => {
       // 댓글 데이터 불러오기
-      const { data: commentsData, error: commentError } = await supabase
+      const { data: commentsData, error } = await supabase
         .from('comments')
-        .select('*')
-        .eq('post_id', post.id);
+        .select('* , profiles(nickname, image)')
+        .eq('post_id', post.id)
+        .order('created_at', { ascending: true }); // 댓글이 생성된 시간을 기준으로 오름차순 정렬
 
-      if (commentError) {
-        console.log('commentError ', commentError);
+      if (error) {
+        console.log('FetchCommentError =====>', error);
         return;
       }
 
-      setComments(
-        commentsData.map((comment) =>
-          setCommentedUserInfo(allUserProfiles, comment),
-        ),
-      );
+      setComments(commentsData);
     };
 
     fetchCommentsData();
@@ -51,36 +47,62 @@ const PostDetailCard = (post) => {
 
   // * 댓글 추가
   const handleAddComment = async (commentInputValue) => {
-    const { data: commentsData, error: commentsError } = await supabase
+    const { data: insertedCommentsData, error } = await supabase
       .from('comments')
       .insert({
         comments: commentInputValue,
         writer_id: user.id,
         post_id: post.id,
       })
-      .select();
+      .select('* , profiles(nickname, image)')
+      .single(); // 추가된 한 개의 댓글만 가져오기
 
-    if (commentsError) {
-      console.log('commentsError =====>', commentsError);
+    if (error) {
+      console.log('AddCommentsError =====>', error);
       return;
     }
 
-    setComments([
-      ...comments,
-      setCommentedUserInfo(allUserProfiles, commentsData[0]),
-    ]);
+    setComments([...comments, insertedCommentsData]);
   };
 
-  const setCommentedUserInfo = (profileData, comment) => {
-    const commentWriterProfile = profileData.find(
-      (profile) => profile.user_id === comment.writer_id,
-    );
+  // * 댓글 수정
+  const handleUpdateComment = async (commentInputValue, commentId) => {
+    const { data: updatedComments, error } = await supabase
+      .from('comments')
+      .update({
+        comments: commentInputValue,
+      })
+      .eq('id', commentId) //
+      .select('* , profiles(nickname, image)')
+      .single(); // 수정된 한 개의 댓글만 가져오기
 
-    return {
-      ...comment,
-      writer_nickname: commentWriterProfile?.nickname,
-      writer_image: commentWriterProfile?.image,
-    };
+    if (error) {
+      console.log('UpdateCommentsError =====>', error);
+      return;
+    }
+
+    // comments 상태에 update 사항 반영
+    setComments((prevComments) =>
+      prevComments.map((comment) =>
+        comment.id === commentId ? updatedComments : comment,
+      ),
+    );
+  };
+
+  // * 댓글 삭제
+  const handleDeleteComment = async (commentId) => {
+    const { error } = await supabase
+      .from('comments')
+      .delete()
+      .eq('id', commentId);
+
+    if (error) {
+      console.log('DeleteCommentsError =====>', error);
+      return;
+    }
+    setComments((prevComments) =>
+      prevComments.filter((comment) => comment.id !== commentId),
+    );
   };
 
   return (
@@ -134,6 +156,8 @@ const PostDetailCard = (post) => {
         <PostCommentArea
           comments={comments}
           handleAddComment={handleAddComment}
+          handleUpdateComment={handleUpdateComment}
+          handleDeleteComment={handleDeleteComment}
         />
       </StCommentSection>
     </>

--- a/src/pages/PostDetail.jsx
+++ b/src/pages/PostDetail.jsx
@@ -7,7 +7,6 @@ import styled from 'styled-components';
 const PostDetail = () => {
   const { id } = useParams();
   const [post, setPost] = useState(undefined);
-  const { user, setUsers } = useState({});
 
   useEffect(() => {
     const fetchData = async () => {

--- a/src/styles/detailCard.styled.js
+++ b/src/styles/detailCard.styled.js
@@ -154,4 +154,13 @@ export const StCommentSection = styled.section`
     width: 100%;
     box-sizing: border-box;
   }
+
+  button {
+    border: none;
+    background: none;
+  }
+
+  button + button {
+    margin-left: 10px;
+  }
 `;

--- a/src/styles/detailCard.styled.js
+++ b/src/styles/detailCard.styled.js
@@ -113,7 +113,6 @@ export const StCommentSection = styled.section`
     color: var(--color-white);
     border: none;
     border-radius: 16px;
-    cursor: pointer;
   }
 
   input {
@@ -149,5 +148,10 @@ export const StCommentSection = styled.section`
     width: 40px;
     height: 40px;
     border-radius: 50%;
+  }
+
+  .commentBottomRow input {
+    width: 100%;
+    box-sizing: border-box;
   }
 `;

--- a/src/styles/globalStyles.js
+++ b/src/styles/globalStyles.js
@@ -9,13 +9,17 @@ export const GlobalStyles = createGlobalStyle`
     --color-green: #95b645;
   }
 
-  body, button {
+  body, button, input {
     font-family: 'Pretendard Variable', Pretendard, sans-serif;
     font-weight: 400;
     line-height: 1.4;
     font-size: 16px;
     letter-spacing: -0.002em;
     color: var(--color-black);
+  }
+
+  button {
+    cursor: pointer;
   }
 
 `;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #1 

<br>

## 📝 작업 내용

> 게시글 내 댓글의 수정과 삭제 기능을 추가했습니다.
- 자신이 작성한 댓글에만 수정/삭제 버튼 노출
- 생성된 일자 기준 오름차순으로 댓글 정렬
- 댓글 수정
- 댓글 삭제 버튼 클릭 시 `confirm`창 노출 → 확인 클릭 시 삭제 반영
- README.md 파일 초안 작성

<br>

## 🖼 스크린샷
### 1. 게시글 댓글 영역
![Project-Whale-2025-02-14-22-43-18](https://github.com/user-attachments/assets/6a75af9e-7d59-4a2e-8bfb-e8561438f109)

### 2. README.md
![image](https://github.com/user-attachments/assets/a4faf0f5-ff42-4629-9999-91ca365d47c5)




<br>

## 💬리뷰 요구사항

> 댓글이 작성, 수정, 삭제된 시점에 해당 요청이 성공적으로 완료되었다는 토스트 알럿을 띄우면 어떨까요? 시간이 여유가 된다면 라이브러리 사용을 의논해봤으면 합니다!
